### PR TITLE
Fix references compiled error

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -28,7 +28,7 @@
   address = {New York, NY, USA},
 }
 
-@InProceedings{AutonomousDriving,
+@inproceedings{AutonomousDriving,
   author={Shao-Hua {Wang} and Sheng-Wen {Cheng} and Ching-Chun (Jim) {Huang}},
   title="Puyuma: Linux-Based RTOS Experimental Platform for Constructing Self-driving Miniature Vehicles",
   booktitle="Intelligent Computing",
@@ -61,20 +61,20 @@
   address = {Berlin, DE},
 }
 
-@online{IOTAwhitepaper,
+@manual{IOTAwhitepaper,
   Author = {S. Popov.},
   title = {Iota whitepaper. Technical White Paper},
   url = {https://iota.org/IOTA_Whitepaper.pdf},
   urldate = {2018-04-30}
 }
 
-@online{MAM,
+@misc{MAM,
   title = {Masked Authenticated Messaging},
   url = {https://blog.iota.org/introducing-masked-authenticated-messaging-e55c1822d50e},
   urldate = {2017-11-05}
 }
 
-@online{IOTADataMarket,
+@misc{IOTADataMarket,
   title = {IOTA Data Marketplace},
   url = {https://data.iota.org},
 }
@@ -87,7 +87,7 @@
   Eprinttype = {arXiv},
 }
 
-@online{IPFS,
+@misc{IPFS,
   Author = {Juan Benet},
   Title = {IPFS - Content Addressed, Versioned, P2P File System},
   Year = {2014},
@@ -95,17 +95,17 @@
   Eprinttype = {arXiv},
 }
 
-@online{smartContract,
+@manual{smartContract,
   title = {ethereum/wiki},
   url = {https://github.com/ethereum/wiki/wiki/White-Paper},
 }
 
-@online{TangleID,
+@misc{TangleID,
   title = {TangleID},
   url = {https://tangleid.github.io},
 }
 
-@online{DID,
+@misc{DID,
   title = {Decentralized Identifiers },
   url = {https://w3c-ccg.github.io/did-spec/},
 }
@@ -146,7 +146,7 @@ year = {2002},
   title = {A Survey on Big Data Market: Pricing, Trading and Protection},
   journal = {IEEE Access},
   year = {2018},
-  pages = {15132 -- 15154},
+  pages = {15132--15154},
   publisher = {IEEE},
 }
 


### PR DESCRIPTION
Some references can't be generated properly due to the wrong keyword in `.bib`.
Please check the correctness of modified categories.